### PR TITLE
[FEAT] Implement rate limit interceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
 			<version>2.8.4</version>
 		</dependency>
 
+		<!-- Bucket4J -->
+		<dependency>
+			<groupId>com.github.vladimir-bukhtoyarov</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>7.6.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/codersthathum/chat_app_service/config/RateLimiterConfig.java
+++ b/src/main/java/com/codersthathum/chat_app_service/config/RateLimiterConfig.java
@@ -1,0 +1,35 @@
+package com.codersthathum.chat_app_service.config;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class RateLimiterConfig {
+
+    @Value("${rate-limiter.capacity}")
+    private long capacity;
+
+    @Value("${rate-limiter.refill-tokens}")
+    private long refillTokens;
+
+    @Value("${rate-limiter.refill-duration}")
+    private long refillDuration;
+
+    // The bucket is shared for all users right now
+    // need to think does it need to be shared or not
+    @Bean
+    public Bucket bucket() {
+        Refill refill = Refill.intervally(refillTokens, Duration.ofSeconds(refillDuration));
+        Bandwidth limit = Bandwidth.classic(capacity, refill);
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+
+}

--- a/src/main/java/com/codersthathum/chat_app_service/config/WebConfig.java
+++ b/src/main/java/com/codersthathum/chat_app_service/config/WebConfig.java
@@ -1,15 +1,23 @@
 package com.codersthathum.chat_app_service.config;
 
 import com.codersthathum.chat_app_service.interceptor.LoggerInterceptor;
+import com.codersthathum.chat_app_service.interceptor.RateLimitInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    private final LoggerInterceptor loggerInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new LoggerInterceptor()).addPathPatterns("/**");
+        registry.addInterceptor(loggerInterceptor).addPathPatterns("/**");
+        registry.addInterceptor(rateLimitInterceptor).addPathPatterns("/**");
     }
 }

--- a/src/main/java/com/codersthathum/chat_app_service/controller/AppExceptionController.java
+++ b/src/main/java/com/codersthathum/chat_app_service/controller/AppExceptionController.java
@@ -1,10 +1,7 @@
 package com.codersthathum.chat_app_service.controller;
 
 import com.codersthathum.chat_app_service.dto.http.HttpResponse;
-import com.codersthathum.chat_app_service.exception.DuplicateResourceException;
-import com.codersthathum.chat_app_service.exception.ForbiddenException;
-import com.codersthathum.chat_app_service.exception.ResourceNotFoundException;
-import com.codersthathum.chat_app_service.exception.UnauthorizedException;
+import com.codersthathum.chat_app_service.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -39,6 +36,13 @@ public class AppExceptionController {
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
                 .body(HttpResponse.error(HttpStatus.FORBIDDEN, ex.getMessage()));
+    }
+
+    @ExceptionHandler(TooManyRequestException.class)
+    public ResponseEntity<HttpResponse<Void>> handleTooManyRequestException(TooManyRequestException ex) {
+        return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(HttpResponse.error(HttpStatus.TOO_MANY_REQUESTS, ex.getMessage()));
     }
 
 }

--- a/src/main/java/com/codersthathum/chat_app_service/exception/TooManyRequestException.java
+++ b/src/main/java/com/codersthathum/chat_app_service/exception/TooManyRequestException.java
@@ -1,0 +1,7 @@
+package com.codersthathum.chat_app_service.exception;
+
+public class TooManyRequestException extends RuntimeException {
+    public TooManyRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/codersthathum/chat_app_service/interceptor/LoggerInterceptor.java
+++ b/src/main/java/com/codersthathum/chat_app_service/interceptor/LoggerInterceptor.java
@@ -4,11 +4,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.UUID;
 
+@Component
 @Slf4j
 public class LoggerInterceptor implements HandlerInterceptor {
 

--- a/src/main/java/com/codersthathum/chat_app_service/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/com/codersthathum/chat_app_service/interceptor/RateLimitInterceptor.java
@@ -1,0 +1,33 @@
+package com.codersthathum.chat_app_service.interceptor;
+
+import com.codersthathum.chat_app_service.exception.TooManyRequestException;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final Bucket bucket;
+
+    @Value("${rate-limiter.enabled}")
+    private boolean enabled;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!enabled) {
+            return true;
+        }
+
+        if (bucket.tryConsume(1)) {
+            return true;
+        }
+
+        throw new TooManyRequestException("Too many requests");
+    }
+}

--- a/src/main/resources/application.example.yaml
+++ b/src/main/resources/application.example.yaml
@@ -18,6 +18,12 @@ spring:
     enabled: true
     baseline-on-migrate: true
 
+rate-limiter:
+  enabled: true
+  capacity: 100
+  refill-tokens: 100
+  refill-duration: 60
+
 jwt:
   secret:
   access-token:


### PR DESCRIPTION
This pull request introduces a rate limiting feature to the chat application service, using the Bucket4J library. The changes include adding necessary dependencies, configuration, and interceptors to enforce rate limiting. Additionally, a new exception is introduced to handle rate limit breaches.

### Dependencies and Configuration:

* Added `Bucket4J` dependency to `pom.xml` to support rate limiting functionality.
* Created `RateLimiterConfig.java` to configure rate limiting parameters such as capacity and refill rate.

### Interceptors:

* Updated `WebConfig.java` to include `RateLimitInterceptor` and use dependency injection for interceptors.
* Added `RateLimitInterceptor.java` to enforce rate limits on incoming requests.

### Exception Handling:

* Added `TooManyRequestException.java` to handle cases where the rate limit is exceeded.
* Updated `AppExceptionController.java` to handle `TooManyRequestException` and return a 429 status code.

### Miscellaneous:

* Updated `application.example.yaml` to include rate limiter configuration properties.
* Added `@Component` annotation to `LoggerInterceptor.java` for proper Spring component scanning.